### PR TITLE
fix_duplicates_in_cold_takes

### DIFF
--- a/align_data/blogs/blogs.py
+++ b/align_data/blogs/blogs.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ColdTakes(HTMLDataset):
     title_selector = 'h2'
-    item_selector = ['article']
+    item_selector = 'div.post-feed article'
 
     cleaner = utils.HtmlCleaner(
         ["You might also like\.\.\..*", "\\n+", "\#\# Create your profile.*", "\n\xa0Comment/discuss\n", '\nClick lower right to download or find on Apple Podcasts, Spotify, Stitcher, etc.\n'],
@@ -52,7 +52,7 @@ class ColdTakes(HTMLDataset):
 
 class GenerativeInk(HTMLDataset):
     title_selector = 'h3'
-    item_selector = ['div', {'class': 'post'}]
+    item_selector = 'div.post.on-list'
 
     def _get_published_date(self, contents):
         possible_date_elements = [

--- a/align_data/blogs/blogs.py
+++ b/align_data/blogs/blogs.py
@@ -7,9 +7,6 @@ from align_data.common.html_dataset import HTMLDataset, RSSDataset
 from datetime import datetime, timezone
 from dateutil.parser import parse
 
-import logging
-logger = logging.getLogger(__name__)
-
 @dataclass
 class ColdTakes(HTMLDataset):
     title_selector = 'h2'

--- a/align_data/blogs/blogs.py
+++ b/align_data/blogs/blogs.py
@@ -7,6 +7,12 @@ from align_data.common.html_dataset import HTMLDataset, RSSDataset
 from datetime import datetime, timezone
 from dateutil.parser import parse
 
+import requests
+from bs4 import BeautifulSoup
+
+import logging
+logger = logging.getLogger(__name__)
+
 @dataclass
 class ColdTakes(HTMLDataset):
     title_selector = 'h2'
@@ -17,6 +23,23 @@ class ColdTakes(HTMLDataset):
         ["", "\\n", "", "", ''],
         True,
     )
+
+    @property
+    def items_list(self):
+        """ 
+        This custom items_list prevents us from getting duplicates 
+        when a url is in the featured section and the main section. 
+        """
+        logger.info(f"Fetching entries from {self.url}")
+        response = requests.get(self.url, allow_redirects=True)
+        soup = BeautifulSoup(response.content, "html.parser")
+            
+        # find the div with class "post-feed"
+        post_feed_div = soup.find('div', class_='post-feed')
+        
+        articles = post_feed_div.find_all(*self.item_selector)
+        logger.info(f"Found {len(articles)} articles")
+        return articles
 
     @staticmethod
     def _get_published_date(contents):

--- a/align_data/blogs/blogs.py
+++ b/align_data/blogs/blogs.py
@@ -7,9 +7,6 @@ from align_data.common.html_dataset import HTMLDataset, RSSDataset
 from datetime import datetime, timezone
 from dateutil.parser import parse
 
-import requests
-from bs4 import BeautifulSoup
-
 import logging
 logger = logging.getLogger(__name__)
 
@@ -23,23 +20,6 @@ class ColdTakes(HTMLDataset):
         ["", "\\n", "", "", ''],
         True,
     )
-
-    @property
-    def items_list(self):
-        """ 
-        This custom items_list prevents us from getting duplicates 
-        when a url is in the featured section and the main section. 
-        """
-        logger.info(f"Fetching entries from {self.url}")
-        response = requests.get(self.url, allow_redirects=True)
-        soup = BeautifulSoup(response.content, "html.parser")
-            
-        # find the div with class "post-feed"
-        post_feed_div = soup.find('div', class_='post-feed')
-        
-        articles = post_feed_div.find_all(*self.item_selector)
-        logger.info(f"Found {len(articles)} articles")
-        return articles
 
     @staticmethod
     def _get_published_date(contents):

--- a/align_data/common/html_dataset.py
+++ b/align_data/common/html_dataset.py
@@ -26,7 +26,7 @@ class HTMLDataset(AlignmentDataset):
     url: str
     done_key = "url"
 
-    authors: List[str] = field(default_factory=list) 
+    authors: List[str] = field(default_factory=list)
     _: KW_ONLY
     source_key: str = None
     summary_key: str = None

--- a/align_data/common/html_dataset.py
+++ b/align_data/common/html_dataset.py
@@ -26,13 +26,13 @@ class HTMLDataset(AlignmentDataset):
     url: str
     done_key = "url"
 
-    authors: List[str] = field(default_factory=list)
+    authors: List[str] = field(default_factory=list) 
     _: KW_ONLY
     source_key: str = None
     summary_key: str = None
 
     title_selector = 'h2'
-    item_selector = ['article']
+    item_selector = 'article'
     source_type = "blog"
 
     cleaner = utils.HtmlCleaner(
@@ -59,7 +59,7 @@ class HTMLDataset(AlignmentDataset):
         logger.info(f"Fetching entries from {self.url}")
         response = requests.get(self.url, allow_redirects=True)
         soup = BeautifulSoup(response.content, "html.parser")
-        articles = soup.find_all(*self.item_selector)
+        articles = soup.select(self.item_selector)
         logger.info(f"Found {len(articles)} articles")
         return articles
 


### PR DESCRIPTION
There was a bug where the dataset would go to https://www.cold-takes.com/, and first take all the urls from the "featured posts" section, and then take all the urls from the "all posts" section, and so the featured posts were all duplicated twice in the cold_takes dataset. Now I ignore the featured posts and the duplicates are gone.