### PR TITLE
Custom_id_from_id_fields

### DIFF
--- a/align_data/alignment_newsletter/alignment_newsletter.py
+++ b/align_data/alignment_newsletter/alignment_newsletter.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 import pandas as pd
 
 from dataclasses import dataclass
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class AlignmentNewsletter(AlignmentDataset):
                 return cast(v)
             return v
 
-        return DataEntry({
+        return self.make_data_entry({
             "url": handle_na(row.URL),
             "source": handle_na(self.name),
             "converted_with": "python",

--- a/align_data/analysis/analyse_jsonl_data.py
+++ b/align_data/analysis/analyse_jsonl_data.py
@@ -23,10 +23,12 @@ def validate_data(data_dict, seen_urls):
     # TODO: add more checks here
 
 def check_for_duplicates(data_dict, seen_urls):
-    if data_dict.get('url') in seen_urls:
-        raise ValueError(f"Duplicate URL found. \nUrl: {data_dict['url']}\nfirst_duplicate: {get_data_dict_str(seen_urls[data_dict['url']])}\nsecond_duplicate: {get_data_dict_str(data_dict)}\n\n\n\n")
+    id = data_dict.get('id')
+    if id in seen_urls:
+        #raise ValueError(f"Duplicate id found. \nId: {id}\nfirst_duplicate: {get_data_dict_str(seen_urls[id])}\nsecond_duplicate: {get_data_dict_str(data_dict)}\n\n\n\n")
+        seen_urls[id].append(data_dict)
     else:
-        seen_urls[data_dict['url']] = data_dict
+        seen_urls[id] = [data_dict]
 
     #TODO: Add more validation logic here
     return seen_urls 
@@ -35,7 +37,7 @@ def get_data_dict_str(data_dict):
     """
     Returns a string representation of the given data_dict.
     """
-    return f"source: {data_dict['source']}, title: {data_dict['title'][:50]}, date_pub: {data_dict['date_published']}, url: {data_dict['url']}"
+    return f"source: {data_dict['source']}, title: {data_dict['title'][:50]}, date_pub: {data_dict['date_published']}, url: {data_dict['url']}\n"
 
 def files_iterator(data_dir):
     """
@@ -55,6 +57,9 @@ def process_jsonl_files(data_dir):
             seen_urls = check_for_duplicates(data_dict, seen_urls)
         except ValueError as e:
             print(e)
+    for id, duplicates in seen_urls.items():
+        if len(duplicates) > 1:
+            print(f"{len(duplicates)} duplicate ids found. \nId: {id}\n{''.join([f'id {i+1}: {get_data_dict_str(duplicate)}' for i, duplicate in enumerate(duplicates)])}\n\n\n\n")
 
 def delete_all_txt_and_jsonl(data_dir):
     """
@@ -67,3 +72,4 @@ def delete_all_txt_and_jsonl(data_dir):
 
 if __name__ == "__main__":
     process_jsonl_files("data/")
+    #delete_all_txt_and_jsonl("data/")

--- a/align_data/analysis/analyse_jsonl_data.py
+++ b/align_data/analysis/analyse_jsonl_data.py
@@ -14,28 +14,54 @@ def is_valid_date_format(data_dict, format="%Y-%m-%dT%H:%M:%SZ"):
     except ValueError:
         return False
 
-def validate_data(data_dict):
+def validate_data(data_dict, seen_urls):
     """
     Processes each dictionary element in the jsonl file. 
     """
     if not is_valid_date_format(data_dict):
         raise ValueError(f"Invalid date format for source: {data_dict['source']}, title: {data_dict['title'][:30]}, date_pub: {data_dict['date_published']}")
     
-    #TODO: Add more validation logic here
+    if data_dict.get('url') in seen_urls:
+        raise ValueError(f"Duplicate URL found. \nUrl: {data_dict['url']}\nfirst_duplicate: {get_data_dict_str(seen_urls[data_dict['url']])}\nsecond_duplicate: {get_data_dict_str(data_dict)}\n\n\n\n")
+    else:
+        seen_urls[data_dict['url']] = data_dict
 
-def process_jsonl_files(data_dir):
+    #TODO: Add more validation logic here
+    return seen_urls 
+
+def get_data_dict_str(data_dict):
+    """
+    Returns a string representation of the given data_dict.
+    """
+    return f"source: {data_dict['source']}, title: {data_dict['title'][:60]}, date_pub: {data_dict['date_published']}, url: {data_dict['url']}"
+
+def files_iterator(data_dir):
     """
     Goes through the data directory, opens every jsonl file sequentially, 
-    and processes every element (which is a dictionary) in the jsonl file.
+    and yields every element (which is a dictionary) in the jsonl file.
     """
     for path in Path(data_dir).glob('*.jsonl'):
         with open(path, encoding='utf-8') as f:
             for line in f:
-                data_dict = json.loads(line)
-                try:
-                    validate_data(data_dict)
-                except ValueError as e:
-                    print(e)
+                yield json.loads(line)
+
+def process_jsonl_files(data_dir):
+    seen_urls = dict()  # holds all seen urls
+    for data_dict in files_iterator(data_dir):
+        try:
+            seen_urls = validate_data(data_dict, seen_urls)
+
+        except ValueError as e:
+            print(e)
+
+def delete_all_txt_and_jsonl(data_dir):
+    """
+    Deletes all txt and jsonl files in the given directory.
+    """
+    for path in Path(data_dir).glob('*.txt'):
+        os.remove(path)
+    for path in Path(data_dir).glob('*.jsonl'):
+        os.remove(path)
 
 if __name__ == "__main__":
     process_jsonl_files("data/")

--- a/align_data/analysis/analyse_jsonl_data.py
+++ b/align_data/analysis/analyse_jsonl_data.py
@@ -72,9 +72,9 @@ def delete_all_txt_and_jsonl(data_dir):
     Deletes all txt and jsonl files in the given directory.
     """
     for path in Path(data_dir).glob('*.txt'):
-        os.remove(path)
+        path.unlink()
     for path in Path(data_dir).glob('*.jsonl'):
-        os.remove(path)
+        path.unlink()
 
 if __name__ == "__main__":
     process_jsonl_files("data/")

--- a/align_data/analysis/analyse_jsonl_data.py
+++ b/align_data/analysis/analyse_jsonl_data.py
@@ -20,7 +20,9 @@ def validate_data(data_dict, seen_urls):
     """
     if not is_valid_date_format(data_dict):
         raise ValueError(f"Invalid date format for source: {data_dict['source']}, title: {data_dict['title'][:30]}, date_pub: {data_dict['date_published']}")
-    
+    # TODO: add more checks here
+
+def check_for_duplicates(data_dict, seen_urls):
     if data_dict.get('url') in seen_urls:
         raise ValueError(f"Duplicate URL found. \nUrl: {data_dict['url']}\nfirst_duplicate: {get_data_dict_str(seen_urls[data_dict['url']])}\nsecond_duplicate: {get_data_dict_str(data_dict)}\n\n\n\n")
     else:
@@ -33,7 +35,7 @@ def get_data_dict_str(data_dict):
     """
     Returns a string representation of the given data_dict.
     """
-    return f"source: {data_dict['source']}, title: {data_dict['title'][:60]}, date_pub: {data_dict['date_published']}, url: {data_dict['url']}"
+    return f"source: {data_dict['source']}, title: {data_dict['title'][:50]}, date_pub: {data_dict['date_published']}, url: {data_dict['url']}"
 
 def files_iterator(data_dir):
     """
@@ -49,8 +51,8 @@ def process_jsonl_files(data_dir):
     seen_urls = dict()  # holds all seen urls
     for data_dict in files_iterator(data_dir):
         try:
-            seen_urls = validate_data(data_dict, seen_urls)
-
+            validate_data(data_dict, seen_urls)
+            seen_urls = check_for_duplicates(data_dict, seen_urls)
         except ValueError as e:
             print(e)
 

--- a/align_data/arbital/arbital.py
+++ b/align_data/arbital/arbital.py
@@ -4,7 +4,7 @@ import requests
 from datetime import datetime, timezone
 from dateutil.parser import parse
 
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -122,7 +122,7 @@ class Arbital(AlignmentDataset):
             page = self.get_page(alias)
             summary, text = extract_text(page['text'])
 
-            return DataEntry({
+            return self.make_data_entry({
                 'title': page.get('title') or '',
                 'text': text,
                 'date_published': self._get_published_date(page),

--- a/align_data/articles/datasets.py
+++ b/align_data/articles/datasets.py
@@ -12,7 +12,7 @@ from markdownify import markdownify
 
 from align_data.articles.pdf import fetch_pdf, read_pdf, fetch
 from align_data.articles.parsers import HTML_PARSERS, extract_gdrive_contents
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ class SpreadsheetDataset(AlignmentDataset):
             logger.error('Could not get text for %s - skipping for now', item.title)
             return None
 
-        return DataEntry({
+        return self.make_data_entry({
             'text': markdownify(text).strip(),
             'url': item.url,
             'title': item.title,

--- a/align_data/arxiv_papers/arxiv_papers.py
+++ b/align_data/arxiv_papers/arxiv_papers.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from markdownify import markdownify
 from bs4 import BeautifulSoup
 from tqdm import tqdm
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class ArxivPapers(AlignmentDataset):
             logger.info(f"Skipping {ids}")
             return None
         else:
-            new_entry = DataEntry({
+            new_entry = self.make_data_entry({
                 "url": self.get_item_key(ids),
                 "source": self.name,
                 "source_type": "html",

--- a/align_data/audio_transcripts/audio_transcripts.py
+++ b/align_data/audio_transcripts/audio_transcripts.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from align_data.common.alignment_dataset import GdocDataset, DataEntry
+from align_data.common.alignment_dataset import GdocDataset
 import logging
 import re
 from datetime import datetime, timezone
@@ -66,7 +66,7 @@ class AudioTranscripts(GdocDataset):
         text = filename.read_text(encoding="utf-8")
         title = filename.stem
 
-        return DataEntry({
+        return self.make_data_entry({
             "source": self.name,
             "source_type": "audio",
             "url": "",

--- a/align_data/blogs/gwern_blog.py
+++ b/align_data/blogs/gwern_blog.py
@@ -51,7 +51,7 @@ class GwernBlog(HTMLDataset):
         metadata = self._get_metadata(parts[0])
         text = self._extract_markdown('...'.join(parts[1:]))
 
-        return DataEntry({
+        return self.make_data_entry({
             "source": self.name,
             "source_type": self.source_type,
             "url": post_href,

--- a/align_data/blogs/gwern_blog.py
+++ b/align_data/blogs/gwern_blog.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from dateutil.parser import parse
 
-from align_data.common.alignment_dataset import DataEntry
 from align_data.common.html_dataset import HTMLDataset
 
 logger = logging.getLogger(__name__)

--- a/align_data/blogs/wp_blog.py
+++ b/align_data/blogs/wp_blog.py
@@ -80,7 +80,7 @@ class WordpressBlog(AlignmentDataset):
             content_text = markdownify(entry["content"][0]["value"]).strip()
             text = entry["title"] + "\n\n" + content_text
             
-            new_entry = DataEntry({
+            new_entry = self.make_data_entry({
                 "text": text,
                 "url": entry['link'],
                 "title": text.split("\n")[0],

--- a/align_data/blogs/wp_blog.py
+++ b/align_data/blogs/wp_blog.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 from markdownify import markdownify
 from align_data.common import utils
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 
 from typing import List
 

--- a/align_data/common/alignment_dataset.py
+++ b/align_data/common/alignment_dataset.py
@@ -25,15 +25,6 @@ INIT_DICT = {
     "authors": lambda: [],
 }
 
-# Used to limit the size of the text used when generating hashes.
-# TODO: Why is this even needed? It doesn't seem likely that any individual entry
-# will be hundreds of MB large, and if not, then why bother with limiting the length of
-# text for hashing? Speed might be an issue, but I'm guessing that I/O, especially network
-# stuff, will be a much larger problem.
-# One possible reason could be dynamic http sites etc. But that's all the more reason to check
-# the whole text, rather than just the header...
-TEXT_LEN = -1
-
 logger = logging.getLogger(__name__)
 
 

--- a/align_data/common/alignment_dataset.py
+++ b/align_data/common/alignment_dataset.py
@@ -63,6 +63,9 @@ class AlignmentDataset:
     _outputted_items = set()
     """A set of the ids of all previously processed items"""
 
+    id_fields = None
+    """A list of fields to use as the id of the entry. If not set, will use the default, ['url', 'title']"""
+
     def __str__(self) -> str:
         return f"{self.name} dataset will be written to {self.jsonl_path}"
 
@@ -89,6 +92,9 @@ class AlignmentDataset:
 
         self._entry_idx += 1
         self._outputted_items.add(entry[self.done_key])
+    
+    def make_data_entry(self, data, **kwargs):
+        return DataEntry(dict(data, **kwargs), id_fields=self.id_fields)
 
     @contextmanager
     def writer(self, out_path=None, overwrite=False):

--- a/align_data/common/alignment_dataset.py
+++ b/align_data/common/alignment_dataset.py
@@ -276,21 +276,20 @@ class DataEntry(UserDict):
         return ''.join(str(self[field]) for field in self.__id_fields).encode("utf-8")
 
     def verify_fields(self):
-        missing = [field for field in self.__id_fields if self.get(field) is None]
+        missing = [field for field in self.__id_fields if not self.get(field)]
         assert not missing, f'Entry is missing the following fields: {missing}'
-
-        id_string = self.generate_id_string()
-        assert id_string, "Entry has empty id_fields"
-        return id_string
         
     def add_id(self):
-        id_string = self.verify_fields()
+        self.verify_fields()
+
+        id_string = self.generate_id_string()
         self["id"] = hashlib.md5(id_string).hexdigest()
 
     def _verify_id(self):
         assert self["id"] is not None, "Entry is missing id"
-        id_string = self.verify_fields()
+        self.verify_fields()
 
+        id_string = self.generate_id_string()
         id_from_fields = hashlib.md5(id_string).hexdigest()
         assert self["id"] == id_from_fields, f"Entry id {self['id']} does not match id from id_fields, {id_from_fields}"
 

--- a/align_data/common/html_dataset.py
+++ b/align_data/common/html_dataset.py
@@ -15,7 +15,6 @@ from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
 
 logger = logging.getLogger(__name__)
 
-
 @dataclass
 class HTMLDataset(AlignmentDataset):
     """
@@ -78,7 +77,7 @@ class HTMLDataset(AlignmentDataset):
             "date_published": date_published,
             "authors": self.extract_authors(contents),
             **self._extra_values(contents),
-        })
+        }, id_fields=["url"])
 
     def _get_contents(self, url):
         logger.info("Fetching {}".format(url))

--- a/align_data/common/html_dataset.py
+++ b/align_data/common/html_dataset.py
@@ -77,7 +77,7 @@ class HTMLDataset(AlignmentDataset):
             "date_published": date_published,
             "authors": self.extract_authors(contents),
             **self._extra_values(contents),
-        }, id_fields=["url"])
+        })
 
     def _get_contents(self, url):
         logger.info("Fetching {}".format(url))

--- a/align_data/common/html_dataset.py
+++ b/align_data/common/html_dataset.py
@@ -11,7 +11,7 @@ import feedparser
 from bs4 import BeautifulSoup
 from markdownify import markdownify
 
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ class HTMLDataset(AlignmentDataset):
         if not text:
             return None
 
-        return DataEntry({
+        return self.make_data_entry({
             "text": text,
             "url": article_url,
             "title": title,

--- a/align_data/ebooks/agentmodels.py
+++ b/align_data/ebooks/agentmodels.py
@@ -1,4 +1,4 @@
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 from dataclasses import dataclass
 from git import Repo
 import logging
@@ -30,7 +30,7 @@ class AgentModels(AlignmentDataset):
         return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def process_entry(self, filename):
-        return DataEntry({
+        return self.make_data_entry({
             'source': self.name,
             'source_type': 'markdown',
             'authors': ['Owain Evans', 'Andreas Stuhlmüller', 'John Salvatier', 'Daniel Filan'],

--- a/align_data/ebooks/gdrive_ebooks.py
+++ b/align_data/ebooks/gdrive_ebooks.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import os
 import pypandoc
 import epub_meta
-from align_data.common.alignment_dataset import GdocDataset, DataEntry
+from align_data.common.alignment_dataset import GdocDataset
 from path import Path
 
 from datetime import datetime, timezone
@@ -48,7 +48,7 @@ class GDrive(GdocDataset):
             logger.error(e)
             return None
 
-        return DataEntry({
+        return self.make_data_entry({
             "source": self.name,
             "source_type": "epub",
             "converted_with": "pandoc",

--- a/align_data/ebooks/mdebooks.py
+++ b/align_data/ebooks/mdebooks.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import re
-from align_data.common.alignment_dataset import GdocDataset, DataEntry
+from align_data.common.alignment_dataset import GdocDataset
 import logging
 from datetime import datetime, timezone
 
@@ -24,7 +24,7 @@ class MDEBooks(GdocDataset):
         title = re.search(r"(.*)-by", filename.name, re.MULTILINE).group(1)
         authors = re.search(r"-by\s(.*)-date", filename.name).group(1)
 
-        return DataEntry({
+        return self.make_data_entry({
             "source": self.name,
             "source_type": "markdown",
             "title": title,

--- a/align_data/gdocs/gdocs.py
+++ b/align_data/gdocs/gdocs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from align_data.common.alignment_dataset import GdocDataset, DataEntry
+from align_data.common.alignment_dataset import GdocDataset
 import logging
 import pypandoc
 from path import Path
@@ -37,7 +37,7 @@ class Gdocs(GdocDataset):
             logger.error(e)
             return None
 
-        return DataEntry({
+        return self.make_data_entry({
             "source": self.name,
             "source_type": "docx",
             "converted_with": "pandoc",

--- a/align_data/greaterwrong/greaterwrong.py
+++ b/align_data/greaterwrong/greaterwrong.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 from tqdm import tqdm
 from markdownify import markdownify
 
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +165,7 @@ class GreaterWrong(AlignmentDataset):
         if item['user']:
             authors = [item['user']] + authors
         authors = [a['displayName'] for a in authors]
-        return DataEntry({
+        return self.make_data_entry({
             'title': item['title'],
             'text': markdownify(item['htmlBody']).strip(),
             'url': item['pageUrl'],

--- a/align_data/reports/reports.py
+++ b/align_data/reports/reports.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from align_data.common.alignment_dataset import GdocDataset, DataEntry
+from align_data.common.alignment_dataset import GdocDataset
 import logging
 import grobid_tei_xml
 
@@ -41,7 +41,7 @@ class Reports(GdocDataset):
             doc_dict = grobid_tei_xml.parse_document_xml(xml_text).to_dict()
             abstract = doc_dict.get("abstract")
             logger.info(f"Doc: {list(doc_dict.keys())}")
-            return DataEntry({
+            return self.make_data_entry({
                 "summary": [abstract] if abstract else [],
                 "authors": [xx["full_name"] for xx in doc_dict["header"]["authors"]],
                 "title": doc_dict["header"]["title"],

--- a/align_data/stampy/__init__.py
+++ b/align_data/stampy/__init__.py
@@ -1,5 +1,5 @@
 from .stampy import Stampy
 
 STAMPY_REGISTRY = [
-    Stampy(name='aisafety.info'),
+    Stampy(name='aisafety.info', id_fields=['url']),
 ]

--- a/align_data/stampy/stampy.py
+++ b/align_data/stampy/stampy.py
@@ -37,6 +37,7 @@ class Stampy(AlignmentDataset):
     def get_item_key(self, entry):
         return html.unescape(entry['Question'])
 
+    
     def _get_published_date(self, entry):
         date_published = entry['Doc Last Edited']
         return super()._get_published_date(date_published)
@@ -60,4 +61,4 @@ class Stampy(AlignmentDataset):
             "authors": ['Stampy aisafety.info'],
             "date_published": self._get_published_date(entry),
             "text": answer,
-        })
+        }, id_fields=['url'])

--- a/align_data/stampy/stampy.py
+++ b/align_data/stampy/stampy.py
@@ -6,7 +6,7 @@ from codaio import Coda, Document
 from datetime import timezone
 from dateutil.parser import parse
 
-from align_data.common.alignment_dataset import AlignmentDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset
 from align_data.settings import CODA_TOKEN, CODA_DOC_ID, ON_SITE_TABLE
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class Stampy(AlignmentDataset):
 
         logger.info(f"Processing {question}")
 
-        return DataEntry({
+        return self.make_data_entry({
             "source": self.name,
             "source_type": "markdown",
             "url": url,
@@ -61,4 +61,4 @@ class Stampy(AlignmentDataset):
             "authors": ['Stampy aisafety.info'],
             "date_published": self._get_published_date(entry),
             "text": answer,
-        }, id_fields=['url'])
+        })

--- a/tests/align_data/common/test_alignment_dataset.py
+++ b/tests/align_data/common/test_alignment_dataset.py
@@ -6,13 +6,14 @@ from datetime import datetime
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
-from align_data.common.alignment_dataset import AlignmentDataset, GdocDataset, DataEntry
+from align_data.common.alignment_dataset import AlignmentDataset, GdocDataset
 
 
 @pytest.fixture
 def data_entries():
+    dataset = AlignmentDataset(name='blaa')
     entries = [
-        DataEntry({
+        dataset.make_data_entry({
             'text': f'line {i}',
             'date_published': f'day {i}',
             'source': f'source {i}',
@@ -33,7 +34,8 @@ def dataset(tmp_path):
 
 
 def test_data_entry_default_fields():
-    entry = DataEntry({})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({})
 
     assert entry == {
         'date_published': None,
@@ -48,7 +50,8 @@ def test_data_entry_default_fields():
 
 def test_data_entry_id_from_urls_and_title():
     data = {'key1': 12, 'key2': 312, 'url': 'www.arbital.org', 'title': 'once upon a time'}
-    entry = DataEntry(data)
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry(data)
     entry.add_id()
     print(entry)
     assert entry == dict({
@@ -63,71 +66,85 @@ def test_data_entry_id_from_urls_and_title():
 
 
 def test_data_entry_no_url_and_title():
-    entry = DataEntry({'key1': 12, 'key2': 312})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'key1': 12, 'key2': 312})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url', 'title'\\]"):
         entry.add_id()
 
 def test_data_entry_no_url():
-    entry = DataEntry({'key1': 12, 'key2': 312, 'title': 'wikipedia goes to war on porcupines'})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'key1': 12, 'key2': 312, 'title': 'wikipedia goes to war on porcupines'})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url'\\]"):
         entry.add_id()
 
 def test_data_entry_none_url():
-    entry = DataEntry({'key1': 12, 'key2': 312, 'url': None})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'key1': 12, 'key2': 312, 'url': None})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url', 'title'\\]"):
         entry.add_id()
 
 def test_data_entry_none_title():
-    entry = DataEntry({'key1': 12, 'key2': 312, 'url': 'www.wikipedia.org', 'title': None})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'key1': 12, 'key2': 312, 'url': 'www.wikipedia.org', 'title': None})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['title'\\]"):
         entry.add_id()
     
 def test_data_entry_empty_url_and_title():
-    entry = DataEntry({'key1': 12, 'key2': 312, 'url': '', 'title': ''})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'key1': 12, 'key2': 312, 'url': '', 'title': ''})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url', 'title'\\]"):
         entry.add_id()
 
 def test_data_entry_empty_url_only():
-    entry = DataEntry({'key1': 12, 'key2': 312, 'url': '', 'title': 'once upon a time'})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'key1': 12, 'key2': 312, 'url': '', 'title': 'once upon a time'})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url'\\]"):
         entry.add_id()
 
 def test_data_entry_empty_title_only():
-    entry = DataEntry({'key1': 12, 'key2': 312, 'url': 'www.wikipedia.org', 'title':''})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'key1': 12, 'key2': 312, 'url': 'www.wikipedia.org', 'title':''})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['title'\\]"):
         entry.add_id()
 
 def test_data_entry_verify_id_passes():
-    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'url': 'www.arbital.org', 'title': 'once upon a time', 'id': '770fe57c8c2130eda08dc392b8696f97'})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'source': 'arbital', 'text': 'once upon a time', 'url': 'www.arbital.org', 'title': 'once upon a time', 'id': '770fe57c8c2130eda08dc392b8696f97'})
     entry._verify_id()
 
 def test_data_entry_verify_id_fails():
-    entry = DataEntry({'url': 'www.arbital.org', 'title': 'once upon a time', 'id': 'f2b4e02fc1dd8ae43845e4f930f2d84f'})
+    dataset = AlignmentDataset(name='blaa')
+    entry = dataset.make_data_entry({'url': 'www.arbital.org', 'title': 'once upon a time', 'id': 'f2b4e02fc1dd8ae43845e4f930f2d84f'})
     with pytest.raises(AssertionError, match='Entry id does not match id_fields'):
         entry._verify_id()
 
 def test_data_entry_id_fields_url_no_url():
-    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time'}, id_fields=['url'])
+    dataset = AlignmentDataset(name='blaa', id_fields=['url'])
+    entry = dataset.make_data_entry({'source': 'arbital', 'text': 'once upon a time'})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url'\\]"):
         entry.add_id()
 
 def test_data_entry_id_fields_url_empty_url():
-    entry = DataEntry({'url': ''}, id_fields=['url'])
+    dataset = AlignmentDataset(name='blaa', id_fields=['url'])
+    entry = dataset.make_data_entry({'url': ''})
     with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url'\\]"):
         entry.add_id()
     
 def test_data_entry_id_fields_url():
-    entry = DataEntry({'url': 'https://www.google.ca/once_upon_a_time'}, id_fields=['url'])
+    dataset = AlignmentDataset(name='blaa', id_fields=['url'])
+    entry = dataset.make_data_entry({'url': 'https://www.google.ca/once_upon_a_time'})
     entry.add_id()
 
 def test_data_entry_id_fields_url_verify_id_passes():
-    entry = DataEntry({'url': 'arbitalonce upon a time', 'id':'809d336a0b9b38c4f585e862317e667d'}, id_fields=['url'])
+    dataset = AlignmentDataset(name='blaa', id_fields=['url'])
+    entry = dataset.make_data_entry({'url': 'arbitalonce upon a time', 'id':'809d336a0b9b38c4f585e862317e667d'})
     entry._verify_id()
 
 def test_data_entry_different_id_from_different_url():
-    entry1 = DataEntry({'url': ' https://aisafety.info?state=6478'}, id_fields=['url'])
+    dataset = AlignmentDataset(name='blaa', id_fields=['url'])
+    entry1 = dataset.make_data_entry({'url': ' https://aisafety.info?state=6478'})
     entry1.add_id()
-    entry2 = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'url': ' https://aisafety.info?state=6479'}, id_fields=['url'])
+    entry2 = dataset.make_data_entry({'source': 'arbital', 'text': 'once upon a time', 'url': ' https://aisafety.info?state=6479'})
     entry2.add_id()
     assert entry1['id'] != entry2['id']
 
@@ -147,7 +164,8 @@ def test_data_entry_different_id_from_different_url():
     ({'id': '457c21e0ecabebcb85c12022d481d9f4', 'url':'www.google.com', 'title': 'Once upon a time'}, 'Entry id [0-9a-fA-F]{32} does not match id from id_fields, [0-9a-fA-F]{32}'),
 ))
 def test_data_entry_verify_id_fails(data, error):
-    entry = DataEntry(data)
+    dataset = AlignmentDataset(name='blaa', id_fields=['url', 'title'])
+    entry = dataset.make_data_entry(data)
     with pytest.raises(AssertionError, match=error):
         entry._verify_id()
 
@@ -284,7 +302,7 @@ def numbers_dataset(tmp_path):
             return item
 
         def process_entry(self, item):
-            return DataEntry({
+            return self.make_data_entry({
                 'text': f'line {item}',
                 'date_published': f'day {item}',
                 'source': f'source {item}',

--- a/tests/align_data/common/test_alignment_dataset.py
+++ b/tests/align_data/common/test_alignment_dataset.py
@@ -50,10 +50,10 @@ def test_data_entry_id_from_urls_and_title():
     data = {'key1': 12, 'key2': 312, 'url': 'www.arbital.org', 'title': 'once upon a time'}
     entry = DataEntry(data)
     entry.add_id()
-
+    print(entry)
     assert entry == dict({
         'date_published': None,
-        'id': '42cdea045ce175c4aa8de1343755d60c',
+        'id': '770fe57c8c2130eda08dc392b8696f97',
         'source': None,
         'text': None,
         'summary': [],
@@ -84,19 +84,21 @@ def test_data_entry_none_title():
     
 def test_data_entry_empty_url_and_title():
     entry = DataEntry({'key1': 12, 'key2': 312, 'url': '', 'title': ''})
-    with pytest.raises(AssertionError, match='Entry has empty id_fields'):
+    with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url', 'title'\\]"):
         entry.add_id()
 
 def test_data_entry_empty_url_only():
     entry = DataEntry({'key1': 12, 'key2': 312, 'url': '', 'title': 'once upon a time'})
-    entry.add_id()
+    with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url'\\]"):
+        entry.add_id()
 
 def test_data_entry_empty_title_only():
     entry = DataEntry({'key1': 12, 'key2': 312, 'url': 'www.wikipedia.org', 'title':''})
-    entry.add_id()
+    with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['title'\\]"):
+        entry.add_id()
 
 def test_data_entry_verify_id_passes():
-    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'url': 'www.arbital.org', 'title': 'once upon a time', 'id': '42cdea045ce175c4aa8de1343755d60c'})
+    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'url': 'www.arbital.org', 'title': 'once upon a time', 'id': '770fe57c8c2130eda08dc392b8696f97'})
     entry._verify_id()
 
 def test_data_entry_verify_id_fails():
@@ -111,7 +113,7 @@ def test_data_entry_id_fields_url_no_url():
 
 def test_data_entry_id_fields_url_empty_url():
     entry = DataEntry({'url': ''}, id_fields=['url'])
-    with pytest.raises(AssertionError, match='Entry has empty id_fields'):
+    with pytest.raises(AssertionError, match="Entry is missing the following fields: \\['url'\\]"):
         entry.add_id()
     
 def test_data_entry_id_fields_url():
@@ -119,7 +121,7 @@ def test_data_entry_id_fields_url():
     entry.add_id()
 
 def test_data_entry_id_fields_url_verify_id_passes():
-    entry = DataEntry({'url': 'arbitalonce upon a time', 'id':'f2b4e02fc1dd8ae43845e4f930f2d84f'}, id_fields=['url'])
+    entry = DataEntry({'url': 'arbitalonce upon a time', 'id':'809d336a0b9b38c4f585e862317e667d'}, id_fields=['url'])
     entry._verify_id()
 
 def test_data_entry_different_id_from_different_url():
@@ -138,7 +140,7 @@ def test_data_entry_different_id_from_different_url():
     ({'id': '123', 'url': None}, "Entry is missing the following fields: \\['url', 'title'\\]"),
     ({'id': '123', 'url': 'www.google.com/'}, "Entry is missing the following fields: \\['title'\\]"),
     ({'id': '123', 'url': 'google', 'text': None}, "Entry is missing the following fields: \\['title'\\]"),
-    ({'id': '123', 'url': '', 'title': ''}, 'Entry has empty id_fields'),
+    ({'id': '123', 'url': '', 'title': ''}, "Entry is missing the following fields: \\['url', 'title'\\]"),
 
     ({'id': '123', 'url':'www.google.com/winter_wonderland','title': 'winter wonderland'}, 'Entry id 123 does not match id from id_fields, [0-9a-fA-F]{32}'),
     ({'id': '457c21e0ecabebcb85c12022d481d9f4', 'url':'www.google.com', 'title': 'winter wonderland'}, 'Entry id [0-9a-fA-F]{32} does not match id from id_fields, [0-9a-fA-F]{32}'),

--- a/tests/align_data/common/test_alignment_dataset.py
+++ b/tests/align_data/common/test_alignment_dataset.py
@@ -43,18 +43,16 @@ def test_data_entry_default_fields():
         'text': None,
         'summary': [],
         'authors': [],
-    }
+    } 
 
-
-def test_data_entry_id_from_text():
-    data = {'key1': 12, 'key2': 312, 'text': 'once upon a time'}
+def test_data_entry_id_from_source_and_text():
+    data = {'key1': 12, 'key2': 312, 'source': 'arbital', 'text': 'once upon a time'}
     entry = DataEntry(data)
     entry.add_id()
 
     assert entry == dict({
         'date_published': None,
-        'id': '457c21e0ecabebcb85c12022d481d9f4',
-        'source': None,
+        'id': 'f2b4e02fc1dd8ae43845e4f930f2d84f',
         'title': None,
         'url': None,
         'summary': [],
@@ -63,20 +61,64 @@ def test_data_entry_id_from_text():
     )
 
 
-def test_data_entry_no_text():
+def test_data_entry_no_source():
     entry = DataEntry({'key1': 12, 'key2': 312})
+    with pytest.raises(AssertionError, match='Entry is missing source'):
+        entry.add_id()
+
+def test_data_entry_no_text():
+    entry = DataEntry({'key1': 12, 'key2': 312, 'source': 'wikipedia'})
     with pytest.raises(AssertionError, match='Entry is missing text'):
         entry.add_id()
 
+def test_data_entry_none_source():
+    entry = DataEntry({'key1': 12, 'key2': 312, 'source': None})
+    with pytest.raises(AssertionError, match='Entry is missing source'):
+        entry.add_id()
 
 def test_data_entry_none_text():
-    entry = DataEntry({'key1': 12, 'key2': 312, 'text': None})
+    entry = DataEntry({'key1': 12, 'key2': 312, 'source': 'wikipedia', 'text': None})
     with pytest.raises(AssertionError, match='Entry is missing text'):
         entry.add_id()
+    
+def test_data_entry_empty_source_and_text():
+    entry = DataEntry({'key1': 12, 'key2': 312, 'source': '', 'text': ''})
+    with pytest.raises(AssertionError, match='Entry has empty id_fields'):
+        entry.add_id()
 
+def test_data_entry_empty_source_only():
+    entry = DataEntry({'key1': 12, 'key2': 312, 'source': '', 'text': 'once upon a time'})
+    entry.add_id()
+
+def test_data_entry_empty_text_only():
+    entry = DataEntry({'key1': 12, 'key2': 312, 'source': 'wikipedia', 'text':''})
+    entry.add_id()
 
 def test_data_entry_verify_id_passes():
-    entry = DataEntry({'text': 'once upon a time', 'id': '457c21e0ecabebcb85c12022d481d9f4'})
+    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'id': 'f2b4e02fc1dd8ae43845e4f930f2d84f'})
+    entry._verify_id()
+
+def test_data_entry_verify_id_fails():
+    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'id': 'f2b4e02fc1dd8ae43845e4f930f2d84f'})
+    with pytest.raises(AssertionError, match='Entry id does not match id_fields'):
+        entry._verify_id()
+
+def test_data_entry_id_fields_url_no_url():
+    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time'}, id_fields=['url'])
+    with pytest.raises(AssertionError, match='Entry is missing url'):
+        entry.add_id()
+
+def test_data_entry_id_fields_url_empty_url():
+    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'url': ''}, id_fields=['url'])
+    with pytest.raises(AssertionError, match='Entry has empty id_fields'):
+        entry.add_id()
+    
+def test_data_entry_id_fields_url():
+    entry = DataEntry({'source': 'arbital', 'text': 'once upon a time', 'url': 'https://www.google.ca/'}, id_fields=['url'])
+    entry.add_id()
+
+def test_data_entry_id_fields_url_verify_id_passes():
+    entry = DataEntry({'url': 'arbitalonce upon a time', 'id':'f2b4e02fc1dd8ae43845e4f930f2d84f'}, id_fields=['url'])
     entry._verify_id()
 
 
@@ -84,12 +126,15 @@ def test_data_entry_verify_id_passes():
     ({'text': 'bla bla bla'}, 'Entry is missing id'),
     ({'text': 'bla bla bla', 'id': None}, 'Entry is missing id'),
 
-    ({'id': '123'}, 'Entry is missing text'),
-    ({'id': '123', 'text': None}, 'Entry is missing text'),
+    ({'id': '123'}, 'Entry is missing source'),
+    ({'id': '123', 'source': None}, 'Entry is missing source'),
+    ({'id': '123', 'source': 'google'}, 'Entry is missing text'),
+    ({'id': '123', 'source': 'google', 'text': None}, 'Entry is missing text'),
+    ({'id': '123', 'source': '', 'text': ''}, 'Entry has empty id_fields'),
 
-    ({'id': '123', 'text': 'winter wonderland'}, 'Entry id does not match text'),
-    ({'id': '457c21e0ecabebcb85c12022d481d9f4', 'text': 'winter wonderland'}, 'Entry id does not match text'),
-    ({'id': '457c21e0ecabebcb85c12022d481d9f4', 'text': 'Once upon a time'}, 'Entry id does not match text'),
+    ({'id': '123', 'source':'google','text': 'winter wonderland'}, 'Entry id does not match id_fields'),
+    ({'id': '457c21e0ecabebcb85c12022d481d9f4', 'source':'google', 'text': 'winter wonderland'}, 'Entry id does not match id_fields'),
+    ({'id': '457c21e0ecabebcb85c12022d481d9f4', 'source':'google', 'text': 'Once upon a time'}, 'Entry id does not match id_fields'),
 ))
 def test_data_entry_verify_id_fails(data, error):
     entry = DataEntry(data)


### PR DESCRIPTION
When creating a DataEntry object, you can now add an optional field, id_fields, which has a default value of ['source', 'text'] currently, and which will use the elements of the id_fields list (concatenated) to create the string that will then be hashed to yield the DataEntry's id. This means that stampy, for example, has the dataentry section changed to:

return DataEntry({
    "source": self.name,
    "source_type": "markdown",
    "url": url,
    "title": question,
    "authors": ['Stampy aisafety.info'],
    "date_published": self._get_published_date(entry),
    "text": answer,
}, id_fields=['url'])
Which means stampy now uses the 'url' only for id_fields. All sources are then easy to modify this way. One glaring problem is that the 'url' in fact does not uniquely describe stampy entries, since some entries have the same url (something to investigate)
