### PR TITLE
Update HF README on upload

### DIFF
--- a/.github/workflows/fetch-dataset.yml
+++ b/.github/workflows/fetch-dataset.yml
@@ -57,7 +57,7 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Fetch dataset
-      run: python main.py fetch ${{ inputs.datasource }}
+      run: python main.py fetch ${{ inputs.datasource }} --fetch_prev=True
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
@@ -81,7 +81,7 @@ jobs:
           python-version: '3.x'
 
       - name: Setup Huggingface client
-        run: pip install huggingface_hub gdown jsonlines
+        run: pip install huggingface_hub gdown jsonlines datasets
 
       - name: Download a single artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/push-datasets.yml
+++ b/.github/workflows/push-datasets.yml
@@ -60,7 +60,7 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Setup Huggingface client
-      run: pip install huggingface_hub
+      run: pip install huggingface_hub gdown jsonlines datasets
 
     - name: Upload files
       run: python upload_to_huggingface.py ${{ secrets.HUGGINGFACE_TOKEN }} ${{ inputs.datasource }}

--- a/align_data/greaterwrong/greaterwrong.py
+++ b/align_data/greaterwrong/greaterwrong.py
@@ -82,7 +82,7 @@ class GreaterWrong(AlignmentDataset):
 
     def get_item_key(self, item):
         return item['pageUrl']
-    
+
     @staticmethod
     def _get_published_date(item):
         date_published = item['postedAt']
@@ -149,9 +149,10 @@ class GreaterWrong(AlignmentDataset):
         if self.jsonl_path.exists() and self.jsonl_path.lstat().st_size:
             with jsonlines.open(self.jsonl_path) as f:
                 for item in f:
-                    pass
-                next_date = item['date_published']
+                    if item['date_published'] > next_date:
+                        next_date = item['date_published']
 
+        logger.info('Starting from %s', next_date)
         while next_date:
             posts = self.fetch_posts(self.make_query(next_date))
             if not posts['results']:
@@ -171,10 +172,10 @@ class GreaterWrong(AlignmentDataset):
         authors = [a['displayName'] for a in authors]
         return DataEntry({
             'title': item['title'],
+            'text': markdownify(item['htmlBody']),
             'url': item['pageUrl'],
             'date_published': self._get_published_date(item),
             'modified_at': item['modifiedAt'],
-            'text': markdownify(item['htmlBody']),
             "source": self.name,
             "source_type": "GreaterWrong",
             'votes': item['voteCount'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ google-auth
 google-auth-oauthlib
 google-auth-httplib2
 google-api-python-client
+gspread

--- a/upload_to_huggingface.py
+++ b/upload_to_huggingface.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import subprocess
 import sys
 from pathlib import Path
 import requests
@@ -36,6 +37,64 @@ def get_gdoc_names(url):
     return [(id, name) for id, name, filetype in id_name_type_iter if name.endswith('.jsonl')]
 
 
+def upload_data_file(api, name, id):
+    """Upload the file with the given `name` to HF.
+
+    If the file already exists locally, it will be used. Otherwise it will first be fetched from the GDrive.
+    """
+    data = Path('data/')
+    filename = data / name
+
+    # Don't download it if it exists locally
+    if not filename.exists():
+        gdown.download(f'https://drive.google.com/uc?id={id}', str(filename), quiet=False)
+    else:
+        print(f'Using local file at {filename}')
+
+    try:
+        # Check that the dowloaded file really contains json lines
+        with jsonlines.open(filename) as reader:
+            reader.read()
+    except InvalidLineError as e:
+        print(e)
+    else:
+        upload(api, filename)
+
+
+def update_readme(api, files):
+    """Update the HuggingFace README with the new metadata.
+
+    Huggingface doesn't seem to provide a nice way of updating the README metadata, hence this
+    mucking around.
+    """
+    # Pretend to create the repo locally
+    repo = Path('alignment-research-dataset')
+    repo.mkdir(exist_ok=True)
+
+    # Fetch the current README and dataset script
+    for filename in ['README.md', 'alignment-research-dataset.py']:
+        with open(repo / filename, 'w') as f:
+            url = f'https://huggingface.co/datasets/StampyAI/alignment-research-dataset/raw/main/{filename}'
+            f.write(requests.get(url).text)
+
+    # Copy over all jsonl files that have been updated, and update the README to have the
+    # current metadata
+    for filename in files:
+        target = Path('data') / filename
+        (repo / filename).write_text(target.read_text())
+        output = subprocess.check_output([
+            'datasets-cli', 'test', 'alignment-research-dataset', '--save_info', f'--name={target.stem}'
+        ])
+
+    # Now upload the updated README
+    api.upload_file(
+        path_or_fileobj=repo / 'README.md',
+        path_in_repo='README.md',
+        repo_id='StampyAI/alignment-research-dataset',
+        repo_type='dataset'
+    )
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2 or not sys.argv[1]:
         print('Usage: python upload_to_huggingface <token> <datasource name | all>')
@@ -49,21 +108,8 @@ if __name__ == "__main__":
 
     data = Path('data/')
     for id, name in files:
-        filename = data / name
+        upload_data_file(api, name, id)
 
-        # Don't download it if it exists locally
-        if not filename.exists():
-            gdown.download(f'https://drive.google.com/uc?id={id}', str(filename), quiet=False)
-        else:
-            print(f'Using local file at {filename}')
-
-        try:
-            # Check that the dowloaded file really contains json lines
-            with jsonlines.open(filename) as reader:
-                reader.read()
-        except InvalidLineError as e:
-            print(e)
-        else:
-            upload(api, data / name)
+    update_readme(api, [name for _, name in files])
 
     print('done')


### PR DESCRIPTION
This will:
* add an option to fetch previous datasets when parsing - this is nice for e.g. lesswrong, as it will only fetch new items, rather than everything
* update the HF README when pushing files - otherwise this step is needed to be done manually each time, which sort of defeats the point