### PR TITLE
Special docs

### DIFF
--- a/.github/workflows/upload-to-huggingface.yml
+++ b/.github/workflows/upload-to-huggingface.yml
@@ -28,22 +28,19 @@ jobs:
           - distill
           - eaforum
           - eleuther.ai
-          - gdocs
           - generative.ink
           - gwern_blog
           - html_articles
           - importai
           - jsteinhardt_blog
           - lesswrong
-          - markdown
           - miri
           - ml_safety_newsletter
           - openai.research
-          - pdfs
           - rob_miles_ai_safety
+          - special_docs
           - vkrakovna_blog
           - yudkowsky_blog
-          - xmls
 
     uses: ./.github/workflows/push-dataset.yml
     with:

--- a/align_data/common/alignment_dataset.py
+++ b/align_data/common/alignment_dataset.py
@@ -106,10 +106,14 @@ class AlignmentDataset:
                 jsonl_writer.write(article.to_dict())
         return filename.resolve()
 
+    @property
+    def _query_items(self):
+        return select(Article).where(Article.source == self.name)
+
     def read_entries(self, sort_by=None):
         """Iterate through all the saved entries."""
         with make_session() as session:
-            query = select(Article).where(Article.source == self.name)
+            query = self._query_items
             if sort_by is not None:
                 query = query.order_by(sort_by)
             for item in session.scalars(query):

--- a/align_data/common/alignment_dataset.py
+++ b/align_data/common/alignment_dataset.py
@@ -85,7 +85,7 @@ class AlignmentDataset:
 
         article = Article(
             id_fields=self.id_fields,
-            meta={k: v for k, v in data.items() if k not in INIT_DICT},
+            meta={k: v for k, v in data.items() if k not in INIT_DICT and v is not None},
             **{k: v for k, v in data.items() if k in INIT_DICT},
         )
         self._add_authors(article, authors)

--- a/align_data/db/models.py
+++ b/align_data/db/models.py
@@ -58,6 +58,7 @@ class Article(Base):
         DateTime, onupdate=func.current_timestamp()
     )
     status: Mapped[Optional[str]] = mapped_column(String(256))
+    comments: Mapped[Optional[str]] = mapped_column(LONGTEXT)  # Editor comments. Can be anything
 
     pinecone_update_required: Mapped[bool] = mapped_column(Boolean, default=False)
 

--- a/align_data/db/models.py
+++ b/align_data/db/models.py
@@ -11,11 +11,10 @@ from sqlalchemy import (
     String,
     Boolean,
     Text,
-    Float,
     func,
     event,
 )
-from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.dialects.mysql import LONGTEXT
 from align_data.settings import PINECONE_METADATA_KEYS
 
@@ -58,6 +57,7 @@ class Article(Base):
     date_updated: Mapped[Optional[datetime]] = mapped_column(
         DateTime, onupdate=func.current_timestamp()
     )
+    status: Mapped[Optional[str]] = mapped_column(String(256))
 
     pinecone_update_required: Mapped[bool] = mapped_column(Boolean, default=False)
 
@@ -90,8 +90,12 @@ class Article(Base):
             "utf-8"
         )
 
+    @property
+    def missing_fields(self):
+        return [field for field in self.__id_fields if not getattr(self, field)]
+
     def verify_fields(self):
-        missing = [field for field in self.__id_fields if not getattr(self, field)]
+        missing = self.missing_fields
         assert not missing, f"Entry is missing the following fields: {missing}"
 
     def verify_id(self):
@@ -107,7 +111,7 @@ class Article(Base):
         for field in self.__table__.columns.keys():
             if field not in ["id", "hash_id", "metadata"] and getattr(other, field):
                 setattr(self, field, getattr(other, field))
-        self.meta.update({k: v for k, v in other.meta.items() if k and v})
+        self.meta = dict((self.meta or {}), **{k: v for k, v in other.meta.items() if k and v})
 
         if other._id:
             self._id = other._id
@@ -120,12 +124,18 @@ class Article(Base):
 
     @classmethod
     def before_write(cls, mapper, connection, target):
-        target.verify_fields()
+        if not target.status and target.missing_fields:
+            target.status = f'missing fields: {", ".join(target.missing_fields)}'
 
         if target.id:
             target.verify_id()
         else:
             target._set_id()
+
+        # This assumes that status pretty much just notes down that an entry is invalid. If it has
+        # all fields set and is being written to the database, then it must have been modified, ergo
+        # should be also updated in pinecone
+        if not target.status:
             target.pinecone_update_required = True
 
     def to_dict(self):
@@ -147,7 +157,7 @@ class Article(Base):
             "date_published": date,
             "authors": authors,
             "summaries": [s.text for s in (self.summaries or [])],
-            **(self.meta or {}),
+            **(meta or {}),
         }
 
 

--- a/align_data/sources/articles/datasets.py
+++ b/align_data/sources/articles/datasets.py
@@ -86,11 +86,6 @@ class SpecialDocs(SpreadsheetDataset):
         if url := self.maybe(item.source_url) or self.maybe(item.url):
             metadata = item_metadata(url)
 
-        text = metadata.get('text')
-        if not text:
-            logger.error('Could not get text for %s - skipping for now', item.title)
-            return None
-
         return self.make_data_entry({
             'source': metadata.get('data_source') or self.name,
             'url': self.maybe(item.url),
@@ -98,7 +93,8 @@ class SpecialDocs(SpreadsheetDataset):
             'source_type': self.maybe(item.source_type),
             'date_published': self._get_published_date(item.date_published) or metadata.get('date_published'),
             'authors': self.extract_authors(item) or metadata.get('authors', []),
-            'text': text,
+            'text': metadata.get('text'),
+            'status': metadata.get('error'),
         })
 
 

--- a/align_data/sources/articles/datasets.py
+++ b/align_data/sources/articles/datasets.py
@@ -1,18 +1,20 @@
-import os
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
-from pypandoc import convert_file
 import pandas as pd
 from gdown.download import download
 from markdownify import markdownify
+from pypandoc import convert_file
+from sqlalchemy import select
 
-from align_data.sources.articles.pdf import read_pdf
-from align_data.sources.articles.parsers import HTML_PARSERS, extract_gdrive_contents, item_metadata
-from align_data.sources.articles.google_cloud import fetch_markdown, fetch_file
 from align_data.common.alignment_dataset import AlignmentDataset
+from align_data.db.models import Article
+from align_data.sources.articles.google_cloud import fetch_file, fetch_markdown
+from align_data.sources.articles.parsers import HTML_PARSERS, extract_gdrive_contents, item_metadata
+from align_data.sources.articles.pdf import read_pdf
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +75,11 @@ class SpreadsheetDataset(AlignmentDataset):
 
 
 class SpecialDocs(SpreadsheetDataset):
+
+    @property
+    def _query_items(self):
+        special_docs_types = ["pdf", "html", "xml", "markdown", "docx"]
+        return select(Article).where(Article.source.in_(special_docs_types))
 
     def process_entry(self, item):
         metadata = {}
@@ -148,7 +155,7 @@ class XMLArticles(SpreadsheetDataset):
 
 
 class MarkdownArticles(SpreadsheetDataset):
-    source_filetype = "md"
+    source_filetype = "markdown"
 
     def _get_text(self, item):
         file_id = item.source_url.split("/")[-2]

--- a/migrations/versions/0d919bdacf00_add_status_column.py
+++ b/migrations/versions/0d919bdacf00_add_status_column.py
@@ -1,0 +1,24 @@
+"""Add status column
+
+Revision ID: 0d919bdacf00
+Revises: 59ac3cb671e3
+Create Date: 2023-08-11 16:52:45.438822
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0d919bdacf00'
+down_revision = '59ac3cb671e3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('articles', sa.Column('status', sa.String(length=256), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('articles', 'status')

--- a/migrations/versions/f5a2bcfa6b2c_add_status_column.py
+++ b/migrations/versions/f5a2bcfa6b2c_add_status_column.py
@@ -1,16 +1,16 @@
 """Add status column
 
-Revision ID: 0d919bdacf00
+Revision ID: f5a2bcfa6b2c
 Revises: 59ac3cb671e3
-Create Date: 2023-08-11 16:52:45.438822
+Create Date: 2023-08-12 15:59:44.741360
 
 """
 from alembic import op
 import sqlalchemy as sa
-
+from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
-revision = '0d919bdacf00'
+revision = 'f5a2bcfa6b2c'
 down_revision = '59ac3cb671e3'
 branch_labels = None
 depends_on = None
@@ -18,7 +18,9 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column('articles', sa.Column('status', sa.String(length=256), nullable=True))
+    op.add_column('articles', sa.Column('comments', mysql.LONGTEXT(), nullable=True))
 
 
 def downgrade() -> None:
+    op.drop_column('articles', 'comments')
     op.drop_column('articles', 'status')

--- a/tests/align_data/articles/test_datasets.py
+++ b/tests/align_data/articles/test_datasets.py
@@ -247,7 +247,7 @@ def test_markdown_articles_process_entry(articles):
             "date_published": "2023-01-01T12:32:11Z",
             "id": None,
             "source": "bla",
-            "source_filetype": "md",
+            "source_filetype": "markdown",
             "source_type": "something",
             "summaries": ["the summary of article 0"],
             "text": "bla bla",

--- a/tests/align_data/common/test_alignment_dataset.py
+++ b/tests/align_data/common/test_alignment_dataset.py
@@ -75,78 +75,26 @@ def test_data_entry_id_from_urls_and_title():
     )
 
 
-def test_data_entry_no_url_and_title():
+@pytest.mark.parametrize('item, error', (
+    ({"key1": 12, "key2": 312}, 'missing fields: url, title'),
+    (
+        {"key1": 12, "key2": 312, "title": "wikipedia goes to war on porcupines"},
+        'missing fields: url'
+    ),
+    ({"key1": 12, "key2": 312, "url": None}, 'missing fields: url, title'),
+    (
+        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": None},
+        'missing fields: title'
+    ),
+    ({"key1": 12, "key2": 312, "url": "", "title": ""}, 'missing fields: url, title'),
+    ({"key1": 12, "key2": 312, "url": "", "title": "once upon a time"}, 'missing fields: url'),
+    ({"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": ""}, 'missing fields: title'),
+))
+def test_data_entry_missing(item, error):
     dataset = AlignmentDataset(name="blaa")
-    entry = dataset.make_data_entry({"key1": 12, "key2": 312})
-    with pytest.raises(
-        AssertionError,
-        match="Entry is missing the following fields: \\['url', 'title'\\]",
-    ):
-        Article.before_write(None, None, entry)
-
-
-def test_data_entry_no_url():
-    dataset = AlignmentDataset(name="blaa")
-    entry = dataset.make_data_entry(
-        {"key1": 12, "key2": 312, "title": "wikipedia goes to war on porcupines"}
-    )
-    with pytest.raises(
-        AssertionError, match="Entry is missing the following fields: \\['url'\\]"
-    ):
-        Article.before_write(None, None, entry)
-
-
-def test_data_entry_none_url():
-    dataset = AlignmentDataset(name="blaa")
-    entry = dataset.make_data_entry({"key1": 12, "key2": 312, "url": None})
-    with pytest.raises(
-        AssertionError,
-        match="Entry is missing the following fields: \\['url', 'title'\\]",
-    ):
-        Article.before_write(None, None, entry)
-
-
-def test_data_entry_none_title():
-    dataset = AlignmentDataset(name="blaa")
-    entry = dataset.make_data_entry(
-        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": None}
-    )
-    with pytest.raises(
-        AssertionError, match="Entry is missing the following fields: \\['title'\\]"
-    ):
-        Article.before_write(None, None, entry)
-
-
-def test_data_entry_empty_url_and_title():
-    dataset = AlignmentDataset(name="blaa")
-    entry = dataset.make_data_entry({"key1": 12, "key2": 312, "url": "", "title": ""})
-    with pytest.raises(
-        AssertionError,
-        match="Entry is missing the following fields: \\['url', 'title'\\]",
-    ):
-        Article.before_write(None, None, entry)
-
-
-def test_data_entry_empty_url_only():
-    dataset = AlignmentDataset(name="blaa")
-    entry = dataset.make_data_entry(
-        {"key1": 12, "key2": 312, "url": "", "title": "once upon a time"}
-    )
-    with pytest.raises(
-        AssertionError, match="Entry is missing the following fields: \\['url'\\]"
-    ):
-        Article.before_write(None, None, entry)
-
-
-def test_data_entry_empty_title_only():
-    dataset = AlignmentDataset(name="blaa")
-    entry = dataset.make_data_entry(
-        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": ""}
-    )
-    with pytest.raises(
-        AssertionError, match="Entry is missing the following fields: \\['title'\\]"
-    ):
-        Article.before_write(None, None, entry)
+    entry = dataset.make_data_entry(item)
+    Article.before_write(None, None, entry)
+    assert entry.status == error
 
 
 def test_data_entry_verify_id_passes():
@@ -174,24 +122,6 @@ def test_data_entry_verify_id_fails():
     )
     with pytest.raises(AssertionError, match="Entry id does not match id_fields"):
         entry.verify_id()
-
-
-def test_data_entry_id_fields_url_no_url():
-    dataset = AlignmentDataset(name="blaa", id_fields=["url"])
-    entry = dataset.make_data_entry({"source": "arbital", "text": "once upon a time"})
-    with pytest.raises(
-        AssertionError, match="Entry is missing the following fields: \\['url'\\]"
-    ):
-        Article.before_write(None, None, entry)
-
-
-def test_data_entry_id_fields_url_empty_url():
-    dataset = AlignmentDataset(name="blaa", id_fields=["url"])
-    entry = dataset.make_data_entry({"url": ""})
-    with pytest.raises(
-        AssertionError, match="Entry is missing the following fields: \\['url'\\]"
-    ):
-        Article.before_write(None, None, entry)
 
 
 def test_data_entry_id_fields_url():


### PR DESCRIPTION
* Uploads all special docs things as a single item to HF (i.e. 'pdfs', 'xmls', etc.)
* Adds a `status` column - this means that special docs items only need to be imported once, at the cost of having partially filled items in the database
* Items with missing required fields will no longer raise an error - now they'll set the appropriate value in the status field