### PR TITLE
Set status for missing fields

### DIFF
--- a/align_data/common/alignment_dataset.py
+++ b/align_data/common/alignment_dataset.py
@@ -25,6 +25,8 @@ INIT_DICT = {
     "url": None,
     "authors": lambda: [],
     "source_type": None,
+    "status": None,
+    "comments": None,
 }
 
 logger = logging.getLogger(__name__)

--- a/align_data/db/models.py
+++ b/align_data/db/models.py
@@ -105,6 +105,10 @@ class Article(Base):
             self.id == id_from_fields
         ), f"Entry id {self.id} does not match id from id_fields: {id_from_fields}"
 
+    def verify_id_fields(self):
+        missing = [field for field in self.__id_fields if not getattr(self, field)]
+        assert not missing, f"Entry is missing the following fields: {missing}"
+
     def update(self, other):
         for field in self.__table__.columns.keys():
             if field not in ["id", "hash_id", "metadata"] and getattr(other, field):
@@ -122,6 +126,8 @@ class Article(Base):
 
     @classmethod
     def before_write(cls, mapper, connection, target):
+        target.verify_id_fields()
+
         if not target.status and target.missing_fields:
             target.status = 'Missing fields'
             target.comments = f'missing fields: {", ".join(target.missing_fields)}'

--- a/align_data/db/models.py
+++ b/align_data/db/models.py
@@ -93,11 +93,8 @@ class Article(Base):
 
     @property
     def missing_fields(self):
-        return [field for field in self.__id_fields if not getattr(self, field)]
-
-    def verify_fields(self):
-        missing = self.missing_fields
-        assert not missing, f"Entry is missing the following fields: {missing}"
+        fields = set(self.__id_fields) | {'text', 'title', 'url', 'source', 'date_published'}
+        return sorted([field for field in fields if not getattr(self, field, None)])
 
     def verify_id(self):
         assert self.id is not None, "Entry is missing id"
@@ -106,7 +103,7 @@ class Article(Base):
         id_from_fields = hashlib.md5(id_string).hexdigest()
         assert (
             self.id == id_from_fields
-        ), f"Entry id {self.id} does not match id from id_fields, {id_from_fields}"
+        ), f"Entry id {self.id} does not match id from id_fields: {id_from_fields}"
 
     def update(self, other):
         for field in self.__table__.columns.keys():
@@ -126,7 +123,8 @@ class Article(Base):
     @classmethod
     def before_write(cls, mapper, connection, target):
         if not target.status and target.missing_fields:
-            target.status = f'missing fields: {", ".join(target.missing_fields)}'
+            target.status = 'Missing fields'
+            target.comments = f'missing fields: {", ".join(target.missing_fields)}'
 
         if target.id:
             target.verify_id()

--- a/align_data/sources/articles/datasets.py
+++ b/align_data/sources/articles/datasets.py
@@ -98,7 +98,8 @@ class SpecialDocs(SpreadsheetDataset):
             'date_published': self._get_published_date(item.date_published) or metadata.get('date_published'),
             'authors': self.extract_authors(item) or metadata.get('authors', []),
             'text': metadata.get('text'),
-            'status': metadata.get('error'),
+            'status': 'Invalid' if metadata.get('error') else None,
+            'comments': metadata.get('error'),
         }
 
     def process_entry(self, item):

--- a/align_data/sources/arxiv_papers/arxiv_papers.py
+++ b/align_data/sources/arxiv_papers/arxiv_papers.py
@@ -64,6 +64,7 @@ def fetch(url) -> Dict:
         paper = {'status': 'Withdrawn'}
     else:
         paper = get_contents(paper_id)
+
     if metadata and metadata.authors:
         authors = metadata.authors
     else:

--- a/tests/align_data/articles/test_datasets.py
+++ b/tests/align_data/articles/test_datasets.py
@@ -371,7 +371,9 @@ def test_arxiv_process_entry_retracted(mock_arxiv):
     """
 
     with patch('requests.get', return_value=Mock(content=response)):
-        assert dataset.process_entry(item).to_dict() == {
+        article = dataset.process_entry(item)
+        assert article.status == 'Withdrawn'
+        assert article.to_dict() == {
             "comment": "no comment",
             "authors": [],
             "categories": "wut",
@@ -386,7 +388,6 @@ def test_arxiv_process_entry_retracted(mock_arxiv):
             "summaries": ["abstract bla bla"],
             "title": "this is the title",
             "url": "https://arxiv.org/abs/2001.11038",
-            "status": "Withdrawn",
             "text": None,
         }
 

--- a/tests/align_data/common/test_alignment_dataset.py
+++ b/tests/align_data/common/test_alignment_dataset.py
@@ -76,48 +76,13 @@ def test_data_entry_id_from_urls_and_title():
 
 
 @pytest.mark.parametrize('item, error', (
-    ({"key1": 12, "key2": 312}, 'missing fields: date_published, source, text, title, url'),
     (
-        {"key1": 12, "key2": 312, "title": "wikipedia goes to war on porcupines"},
-        'missing fields: date_published, source, text, url'
+        {"key1": 12, "key2": 312, "title": "wikipedia goes to war on porcupines", "url": "asd"},
+        'missing fields: date_published, source, text'
     ),
     (
-        {"key1": 12, "key2": 312, "url": None},
-        'missing fields: date_published, source, text, title, url'
-    ),
-    (
-        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": None},
-        'missing fields: date_published, source, text, title'
-    ),
-    (
-        {"key1": 12, "key2": 312, "url": "", "title": ""},
-        'missing fields: date_published, source, text, title, url'
-    ),
-    (
-        {"key1": 12, "key2": 312, "url": "", "title": "once upon a time"},
-        'missing fields: date_published, source, text, url'
-    ),
-    (
-        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": ""},
-        'missing fields: date_published, source, text, title'
-    ),
-    (
-        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "text": "asdasd"},
-        'missing fields: date_published, source, title'
-    ),
-
-    (
-        {
-            "key1": 12, "key2": 312, "title": "bla", "text": "asdasd", "source": "dwe", "date_published": "dwe"
-        },
-        'missing fields: url'
-    ),
-    (
-        {
-            "key1": 12, "key2": 312, "url": "www.wikipedia.org",
-            "text": "asdasd", "source": "dwe", "date_published": "dwe"
-        },
-        'missing fields: title'
+        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "text": "asdasd", "title": "asdasd"},
+        'missing fields: date_published, source'
     ),
     (
         {
@@ -174,6 +139,35 @@ def test_data_entry_verify_id_fails():
     expected = 'Entry id f2b4e02fc1dd8ae43845e4f930f2d84f does not match id from id_fields: 770fe57c8c2130eda08dc392b8696f97'
     with pytest.raises(AssertionError, match=expected):
         entry.verify_id()
+
+
+@pytest.mark.parametrize(
+    "data, error",
+    (
+        ({"id": "123"}, "Entry is missing the following fields: \\['url', 'title'\\]"),
+        (
+            {"id": "123", "url": None},
+            "Entry is missing the following fields: \\['url', 'title'\\]",
+        ),
+        (
+            {"id": "123", "url": "www.google.com/"},
+            "Entry is missing the following fields: \\['title'\\]",
+        ),
+        (
+            {"id": "123", "url": "google", "text": None},
+            "Entry is missing the following fields: \\['title'\\]",
+        ),
+        (
+            {"id": "123", "url": "", "title": ""},
+            "Entry is missing the following fields: \\['url', 'title'\\]",
+        ),
+    ),
+)
+def test_data_entry_verify_fields_fails(data, error):
+    dataset = AlignmentDataset(name="blaa", id_fields=["url", "title"])
+    entry = dataset.make_data_entry(data)
+    with pytest.raises(AssertionError, match=error):
+        entry.verify_id_fields()
 
 
 def test_data_entry_id_fields_url():

--- a/tests/align_data/common/test_alignment_dataset.py
+++ b/tests/align_data/common/test_alignment_dataset.py
@@ -76,25 +76,76 @@ def test_data_entry_id_from_urls_and_title():
 
 
 @pytest.mark.parametrize('item, error', (
-    ({"key1": 12, "key2": 312}, 'missing fields: url, title'),
+    ({"key1": 12, "key2": 312}, 'missing fields: date_published, source, text, title, url'),
     (
         {"key1": 12, "key2": 312, "title": "wikipedia goes to war on porcupines"},
-        'missing fields: url'
+        'missing fields: date_published, source, text, url'
     ),
-    ({"key1": 12, "key2": 312, "url": None}, 'missing fields: url, title'),
+    (
+        {"key1": 12, "key2": 312, "url": None},
+        'missing fields: date_published, source, text, title, url'
+    ),
     (
         {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": None},
+        'missing fields: date_published, source, text, title'
+    ),
+    (
+        {"key1": 12, "key2": 312, "url": "", "title": ""},
+        'missing fields: date_published, source, text, title, url'
+    ),
+    (
+        {"key1": 12, "key2": 312, "url": "", "title": "once upon a time"},
+        'missing fields: date_published, source, text, url'
+    ),
+    (
+        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": ""},
+        'missing fields: date_published, source, text, title'
+    ),
+    (
+        {"key1": 12, "key2": 312, "url": "www.wikipedia.org", "text": "asdasd"},
+        'missing fields: date_published, source, title'
+    ),
+
+    (
+        {
+            "key1": 12, "key2": 312, "title": "bla", "text": "asdasd", "source": "dwe", "date_published": "dwe"
+        },
+        'missing fields: url'
+    ),
+    (
+        {
+            "key1": 12, "key2": 312, "url": "www.wikipedia.org",
+            "text": "asdasd", "source": "dwe", "date_published": "dwe"
+        },
         'missing fields: title'
     ),
-    ({"key1": 12, "key2": 312, "url": "", "title": ""}, 'missing fields: url, title'),
-    ({"key1": 12, "key2": 312, "url": "", "title": "once upon a time"}, 'missing fields: url'),
-    ({"key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": ""}, 'missing fields: title'),
+    (
+        {
+            "key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": "bla",
+            "source": "dwe", "date_published": "dwe"
+        },
+        'missing fields: text'
+    ),
+    (
+        {
+            "key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": "bla",
+            "text": "asdasd", "date_published": "dwe"
+        },
+        'missing fields: source'
+    ),
+    (
+        {
+            "key1": 12, "key2": 312, "url": "www.wikipedia.org", "title": "bla", "text": "asdasd", "source": "dwe"
+        },
+        'missing fields: date_published'
+    ),
 ))
 def test_data_entry_missing(item, error):
     dataset = AlignmentDataset(name="blaa")
     entry = dataset.make_data_entry(item)
     Article.before_write(None, None, entry)
-    assert entry.status == error
+    assert entry.status == 'Missing fields'
+    assert entry.comments == error
 
 
 def test_data_entry_verify_id_passes():
@@ -120,7 +171,8 @@ def test_data_entry_verify_id_fails():
             "id": "f2b4e02fc1dd8ae43845e4f930f2d84f",
         }
     )
-    with pytest.raises(AssertionError, match="Entry id does not match id_fields"):
+    expected = 'Entry id f2b4e02fc1dd8ae43845e4f930f2d84f does not match id from id_fields: 770fe57c8c2130eda08dc392b8696f97'
+    with pytest.raises(AssertionError, match=expected):
         entry.verify_id()
 
 
@@ -151,73 +203,6 @@ def test_data_entry_different_id_from_different_url():
         }
     )
     assert entry1.generate_id_string() != entry2.generate_id_string()
-
-
-@pytest.mark.parametrize(
-    "data, error",
-    (
-        ({"text": "bla bla bla"}, "Entry is missing id"),
-        ({"text": "bla bla bla", "id": None}, "Entry is missing id"),
-        (
-            {
-                "id": "123",
-                "url": "www.google.com/winter_wonderland",
-                "title": "winter wonderland",
-            },
-            "Entry id 123 does not match id from id_fields, [0-9a-fA-F]{32}",
-        ),
-        (
-            {
-                "id": "457c21e0ecabebcb85c12022d481d9f4",
-                "url": "www.google.com",
-                "title": "winter wonderland",
-            },
-            "Entry id [0-9a-fA-F]{32} does not match id from id_fields, [0-9a-fA-F]{32}",
-        ),
-        (
-            {
-                "id": "457c21e0ecabebcb85c12022d481d9f4",
-                "url": "www.google.com",
-                "title": "Once upon a time",
-            },
-            "Entry id [0-9a-fA-F]{32} does not match id from id_fields, [0-9a-fA-F]{32}",
-        ),
-    ),
-)
-def test_data_entry_verify_id_fails(data, error):
-    dataset = AlignmentDataset(name="blaa", id_fields=["url", "title"])
-    entry = dataset.make_data_entry(data)
-    with pytest.raises(AssertionError, match=error):
-        entry.verify_id()
-
-
-@pytest.mark.parametrize(
-    "data, error",
-    (
-        ({"id": "123"}, "Entry is missing the following fields: \\['url', 'title'\\]"),
-        (
-            {"id": "123", "url": None},
-            "Entry is missing the following fields: \\['url', 'title'\\]",
-        ),
-        (
-            {"id": "123", "url": "www.google.com/"},
-            "Entry is missing the following fields: \\['title'\\]",
-        ),
-        (
-            {"id": "123", "url": "google", "text": None},
-            "Entry is missing the following fields: \\['title'\\]",
-        ),
-        (
-            {"id": "123", "url": "", "title": ""},
-            "Entry is missing the following fields: \\['url', 'title'\\]",
-        ),
-    ),
-)
-def test_data_entry_verify_fields_fails(data, error):
-    dataset = AlignmentDataset(name="blaa", id_fields=["url", "title"])
-    entry = dataset.make_data_entry(data)
-    with pytest.raises(AssertionError, match=error):
-        entry.verify_fields()
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently rows with missing non id keys (e.g. the text column, which is pretty much the most important one...) will not have their status changed to reflect that. This should fix it.
This also sort of stops pinecone from embedding them, albeit in a somewhat fragile way. The current approach is for pinecone to process everything that has the `pinecone_update_required` flag set to true. This is set whenever an article is saved, but only if the article doesn't have an invalid status set (or currently only if its status is NULL). As long as the status gets correctly set for bad states, this is fine.