### PR TITLE
Arbital refactor

### DIFF
--- a/align_data/sources/arbital/arbital.py
+++ b/align_data/sources/arbital/arbital.py
@@ -66,7 +66,7 @@ def markdownify_text(current: List[str], view: Iterator[Tuple[str, str]]) -> Tup
         current = []
         view = iter([('[', 'summary: A behaviorist '), ('summary: A behaviorist ', '['), ('[', '6w genie'), ('6w genie', ']'), (']', ']'), (']', None)])
     The function should return:
-        ('summary: A behaviorist [genie](https://arbital.com/p/6w)', '')
+        ('A behaviorist [genie](https://arbital.com/p/6w)', '')
     
     Note:
     This function assumes that `view` provides a valid Arbital markdown sequence. Malformed sequences might lead to 
@@ -78,8 +78,8 @@ def markdownify_text(current: List[str], view: Iterator[Tuple[str, str]]) -> Tup
     for part, next_part in view:
         if part == "[":
             # Recursively try to parse this new section - it's probably a link, but can be something else
-            sum, text = markdownify_text([part], view)
-            summary += sum + "\n\n"
+            sub_summary, text = markdownify_text([part], view)
+            summary += sub_summary + "\n\n"
             current.append(text)
 
         elif part == "]":
@@ -88,9 +88,11 @@ def markdownify_text(current: List[str], view: Iterator[Tuple[str, str]]) -> Tup
                 current.append(part)
                 in_link = True
             else:
-                # this is the arbital summary - just join it for now, but it'll have to be handled later
+                # this is the arbital summary - we return it as a summary, 
+                # and strip characters from the summary's text
                 if current[1].startswith("summary"):
-                    return "".join(current[1:]), ""
+                    summary_tag, summary = "".join(current[1:]).split(":", 1)
+                    return summary_tag + ": " + summary.strip(), ""
                 # if this was a TODO section, then ignore it
                 if current[1].startswith("todo"):
                     return "", ""

--- a/align_data/sources/arbital/arbital.py
+++ b/align_data/sources/arbital/arbital.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class Page(TypedDict, total=False):
+    text: str
     likeableId: str
     likeableType: str
     title: str
@@ -35,11 +36,17 @@ def parse_arbital_link(internal_link: str) -> str:
     :rtype: str
 
     Typical format: `123 Some title` -> `[Some title](https://arbital.com/p/123)`
+    Special cases: 
+        `toc:` -> `toc:`
+        `https://www.gwern.net/ Gwern Branwen` -> `[Gwern Branwen](https://www.gwern.net/)`
     """
     page_id, *title_parts = internal_link.split(" ")
-    if not page_id:
+    if not page_id or page_id.startswith("toc:"):
         # could be a regular text bracket, ignore it
         return internal_link
+    if page_id.startswith("http"):
+        # could be a regular link, ignore it
+        return f"[{' '.join(title_parts)}]({page_id})"
     url = f"https://arbital.com/p/{page_id}"
     title = " ".join(title_parts) if title_parts else url
     return f"[{title}]({url})"

--- a/tests/align_data/sources/test_arbital.py
+++ b/tests/align_data/sources/test_arbital.py
@@ -84,37 +84,38 @@ def test_markdownify_text_contents_arbital_markdown(text, expected):
     (
         (
             "[summary: summaries should be extracted] bla bla bla",
-            "summaries should be extracted",
+            ("summary: summaries should be extracted", "bla bla bla"),
         ),
         (
             "[summary: \n    whitespace should be stripped       \n] bla bla bla",
-            "whitespace should be stripped",
+            ("summary: whitespace should be stripped", "bla bla bla"),
         ),
         (
             "[summary(Bold): special summaries should be extracted] bla bla bla",
-            "special summaries should be extracted",
+            ("summary(Bold): special summaries should be extracted", "bla bla bla"),
         ),
         (
             "[summary(Markdown): special summaries should be extracted] bla bla bla",
-            "special summaries should be extracted",
+            ("summary(Markdown): special summaries should be extracted", "bla bla bla"),
         ),
         (
             "[summary(BLEEEE): special summaries should be extracted] bla bla bla",
-            "special summaries should be extracted",
+            ("summary(BLEEEE): special summaries should be extracted", "bla bla bla"),
         ),
         (
             "[summary: markdown is handled: [bla](https://bla.bla)] bla bla bla",
-            "markdown is handled: [bla](https://bla.bla)",
+            ("summary: markdown is handled: [bla](https://bla.bla)", "bla bla bla"),
         ),
         (
             "[summary: markdown is handled: [123 ble ble]] bla bla bla",
-            "markdown is handled: [ble ble](https://arbital.com/p/123)",
+            ("summary: markdown is handled: [ble ble](https://arbital.com/p/123)", "bla bla bla"),
         ),
     ),
 )
-def test_markdownify_text_summary(text, expected):
-    summary, _ = extract_text(text)
-    assert summary == expected
+def test_markdownify_text_summary_and_content(text, expected):
+    summary, text = extract_text(text)
+    assert summary == expected[0]
+    assert text == expected[1]
 
 
 @pytest.fixture

--- a/tests/align_data/sources/test_arbital.py
+++ b/tests/align_data/sources/test_arbital.py
@@ -21,6 +21,8 @@ from align_data.sources.arbital.arbital import (
             "123 Some title with multiple words",
             "[Some title with multiple words](https://arbital.com/p/123)",
         ),
+        ("https://www.gwern.net/ Gwern Branwen", "[Gwern Branwen](https://www.gwern.net/)"),
+        ("toc:", "toc:"),  # `toc:` is a mysterious thing
     ),
 )
 def test_parse_arbital_link(contents, expected):

--- a/tests/align_data/sources/test_arbital.py
+++ b/tests/align_data/sources/test_arbital.py
@@ -15,10 +15,10 @@ from align_data.sources.arbital.arbital import (
 @pytest.mark.parametrize(
     "contents, expected",
     (
-        (["[", "123"], "[https://arbital.com/p/123](https://arbital.com/p/123)"),
-        (["[", "123 Some title"], "[Some title](https://arbital.com/p/123)"),
+        ("123", "[https://arbital.com/p/123](https://arbital.com/p/123)"),
+        ("123 Some title", "[Some title](https://arbital.com/p/123)"),
         (
-            ["[", "123 Some title with multiple words"],
+            "123 Some title with multiple words",
             "[Some title with multiple words](https://arbital.com/p/123)",
         ),
     ),


### PR DESCRIPTION
modified a few functions, especially markdownify_text, so that summaries are saved as summaries rather than as part of the text
+ tests