### PR TITLE
Validate MIN_CONFIDENCE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,17 @@
 LOG_LEVEL="INFO"
+MIN_CONFIDENCE="0.5"
+
 CODA_TOKEN=""
+YOUTUBE_API_KEY=""
+
 ARD_DB_USER="user"
 ARD_DB_PASSWORD="we all live in a yellow submarine"
 ARD_DB_HOST="127.0.0.1"
 ARD_DB_PORT="3306"
 ARD_DB_NAME="alignment_research_dataset"
+
 OPENAI_API_KEY="sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
 PINECONE_INDEX_NAME="stampy-chat-ard"
 PINECONE_API_KEY="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 PINECONE_ENVIRONMENT="xx-xxxxx-gcp"
-YOUTUBE_API_KEY=""

--- a/align_data/db/session.py
+++ b/align_data/db/session.py
@@ -44,7 +44,7 @@ def get_pinecone_articles_by_sources(
 
 def get_pinecone_articles_by_ids(
     session: Session,
-    hash_ids: List[int],
+    hash_ids: List[str],
     force_update: bool = False,
 ):
     return get_pinecone_articles(session, force_update).filter(Article.id.in_(hash_ids))

--- a/align_data/settings.py
+++ b/align_data/settings.py
@@ -89,5 +89,8 @@ OPENAI_CURRENT_BEST_FINETUNED_LAYER_PATH = os.environ.get(
 )
 
 ### MISCELLANEOUS ###
-MIN_CONFIDENCE = 50
+MIN_CONFIDENCE = float(os.environ.get('MIN_CONFIDENCE') or '0.5')
+if MIN_CONFIDENCE < 0 or MIN_CONFIDENCE > 1:
+    raise ValueError(f'MIN_CONFIDENCE must be between 0 and 1 - got {MIN_CONFIDENCE}')
+
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"


### PR DESCRIPTION
Properly handle MIN_CONFIDENCE and make sure it has a correct value.

One downside of this approach is that MIN_CONFIDENCE isn't needed when parsing stuff, only when adding to pinecone. So MIN_CONFIDENCE will be validated even when not needed. The alternative would be to have a getter function (or something), or to check it in each place it's used. The first option adds another layer of abstraction, while the second one will at some point be forgotten and there will be a flow that uses it but doesn't check it (Moore's law)