### PR TITLE
Docker: Add the NLTK punkt installation, allowing pinecone updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ USER ard:ard
 RUN python -m pip install --upgrade pip
 RUN pip3 install torch --index-url https://download.pytorch.org/whl/cpu
 RUN pip install -r requirements.txt
+RUN python -c 'import nltk; nltk.download("punkt"); nltk.download("punkt_tab");'
 
 CMD ["python", "main.py", "fetch-all"]


### PR DESCRIPTION
This makes it possible to override the Docker image's entrypoint (e.g. to `sh -c "python main.py fetch-all && python main.py pinecone_update_all"`) to also include updating the Pinecone vector DB, by ensuring that the required punkt tokenizer is installed, as in the [update-pinecone GitHub workflow](https://github.com/StampyAI/alignment-research-dataset/blob/f6fbcee/.github/workflows/update-pinecone.yml#L64).