### PR TITLE
[Claude] Fix delete_entries not flattening paginated Pinecone list results

### DIFF
--- a/align_data/embeddings/pinecone/pinecone_db_handler.py
+++ b/align_data/embeddings/pinecone/pinecone_db_handler.py
@@ -324,7 +324,9 @@ class PineconeDB:
             for article_id in chunk:
                 article_vectors = self._find_item(article_id)
                 if article_vectors:
-                    vector_ids.extend(article_vectors)
+                    # _find_item returns paginated results: a list of pages,
+                    # each page being a list of vector ID strings. Flatten them.
+                    vector_ids.extend(vid for page in article_vectors for vid in page)
 
             if vector_ids:
                 self._del_items(vector_ids)


### PR DESCRIPTION
## Summary

(This PR was created entirely by an autonomous Claude instance and has not yet been reviewed by Lauren.)

`delete_entries()` fails with a 400 error when deleting articles that have more than ~1000 vector chunks in Pinecone.

### The bug

`_find_item()` calls `self.index.list(prefix=id_, namespace=...)` which returns **paginated results**: a list of pages, where each page is a list of up to 100 vector ID strings. For example, an article with 1,213 vectors returns:

```python
[
    ['hash_001a...', 'hash_0174...', ...],  # page 1: 100 IDs
    ['hash_2a36...', 'hash_3d48...', ...],  # page 2: 100 IDs
    ...
    ['hash_fda6...', ...],                   # page 13: 13 IDs
]
```

`delete_entries()` then does `vector_ids.extend(article_vectors)`, which appends the **page lists themselves** rather than the IDs inside them. So `vector_ids` becomes a list of lists. When this is passed to `_del_items()`, `chunk_items` counts pages (not IDs), and a batch of 10 articles whose vectors span 15+ pages gets sent as a single delete request with all ~1,500 IDs, exceeding Pinecone's 1,000 ID per request limit.

### How I found it

While running a bulk deletion of 6,336 articles' stale vectors (fixing corrupted text from the `validate_text` bug in PR #231), the deletion failed with:

```
{"code":3,"message":"Number of provided IDs: 1512 exceeds the maximum amount per request: 1000","details":[]}
```

I confirmed the return type by calling `idx.list(prefix=..., namespace=...)` directly and observing it returns `list[list[str]]`, not `list[str]`.

### The fix

One line: flatten the pages when extending `vector_ids`.

```python
# before
vector_ids.extend(article_vectors)

# after
vector_ids.extend(vid for page in article_vectors for vid in page)
```

## Test plan

- [ ] pytest passes
- [ ] Manually verify deletion works for an article with >1000 vectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)