### PR TITLE
Fix Pinecone() environment kwarg removed in SDK 9

### DIFF
--- a/align_data/embeddings/pinecone/pinecone_db_handler.py
+++ b/align_data/embeddings/pinecone/pinecone_db_handler.py
@@ -14,7 +14,6 @@ from align_data.settings import (
     EMBEDDINGS_DIMS,
     PINECONE_METRIC,
     PINECONE_API_KEY,
-    PINECONE_ENVIRONMENT,
     PINECONE_NAMESPACE,
 )
 
@@ -121,12 +120,14 @@ def with_pinecone_retry(f):
 
 
 def initialize_pinecone():
-    """Initialize Pinecone client with compatibility for both API versions."""
+    """Initialize Pinecone client.
+
+    Pinecone SDK 3+ uses serverless indexes (see create_index below) and no longer
+    accepts the legacy `environment` kwarg removed in SDK 9. API key is the only
+    required argument; index region lives on ServerlessSpec.
+    """
     try:
-        return Pinecone(
-            api_key=PINECONE_API_KEY,
-            environment=PINECONE_ENVIRONMENT,
-        )
+        return Pinecone(api_key=PINECONE_API_KEY)
     except Exception as e:
         logger.error(f"Failed to initialize Pinecone: {e}")
         raise

--- a/align_data/settings.py
+++ b/align_data/settings.py
@@ -78,7 +78,6 @@ OPENAI_ORGANIZATION = os.environ.get("OPENAI_ORGANIZATION")
 ### PINECONE ###
 PINECONE_INDEX_NAME = os.environ.get("PINECONE_INDEX_NAME", "stampy-chat-context-2")
 PINECONE_API_KEY = os.environ.get("PINECONE_API_KEY", None)
-PINECONE_ENVIRONMENT = os.environ.get("PINECONE_ENVIRONMENT", None)
 PINECONE_METRIC = "cosine"
 PINECONE_NAMESPACE = os.environ.get(
     "PINECONE_NAMESPACE", "voyage-chunk-3-table20251208"

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ transformers
 regex
 tqdm==4.66.1
 openai
-pinecone
+pinecone>=9,<10  # SDK 9 removed environment kwarg; next major may break again
 voyageai>=0.3.5  # voyage-context-3 requires 0.3.5+

--- a/tests/align_data/embeddings/test_pinecone_db_handler.py
+++ b/tests/align_data/embeddings/test_pinecone_db_handler.py
@@ -16,17 +16,19 @@ from align_data.embeddings.pinecone.pinecone_db_handler import (
 class TestPineconeInitialization:
     """Tests for Pinecone initialization."""
 
-    @patch("align_data.embeddings.pinecone.pinecone_db_handler.Pinecone")
-    def test_initialize_pinecone(self, mock_pinecone):
-        """Test initialization with the Pinecone API."""
-        mock_client = MagicMock()
-        mock_pinecone.return_value = mock_client
+    @patch("align_data.embeddings.pinecone.pinecone_db_handler.PINECONE_API_KEY", "fake-key-for-tests")
+    def test_initialize_pinecone_uses_supported_kwargs(self):
+        """initialize_pinecone must pass only kwargs the installed SDK accepts.
 
-        client = initialize_pinecone()
+        Regression: passing environment= worked through SDK 8 but Pinecone 9 (released
+        ~May 2026) removed the kwarg, breaking daily/weekly cron pipelines. Uses the
+        real Pinecone class (no mock) so a future SDK that drops another kwarg fails
+        loudly at test time instead of at 02:30 in production.
+        """
+        from pinecone import Pinecone
 
-        # Check that the API was called correctly
-        mock_pinecone.assert_called_once()
-        assert client == mock_client
+        client = initialize_pinecone()  # Real Pinecone constructor; no network on init.
+        assert isinstance(client, Pinecone)
 
     @patch("align_data.embeddings.pinecone.pinecone_db_handler.Pinecone")
     def test_initialize_pinecone_with_error(self, mock_pinecone):


### PR DESCRIPTION
## What's broken

Every daily cron run since 2026-05-05, plus the May 10 weekly and Pinecone-update runs, has failed at:

```
TypeError: Pinecone() got unexpected keyword arguments: ['environment']
```

Pinecone SDK 9, released in early May, removed the legacy `environment` kwarg from the `Pinecone()` constructor. `requirements.txt` had `pinecone` unpinned, so the May 5 cron picked up SDK 9 and every run since has crashed at `initialize_pinecone()`.

(The earlier April 11 failure that prompted this investigation was unrelated — a one-off SSL glitch during `pip install`.)

## Decisions

### From @lauren
- Investigate the GH Actions failures and fix if it's a code issue
- Open this PR

### From Claude
- **Drop `environment=` rather than try to map it to something.** The codebase already uses `ServerlessSpec(cloud="aws", region="us-east-1")` in `create_index`, so region info lives on the spec and the kwarg was dead weight even before SDK 9 enforced it.
- **Delete `PINECONE_ENVIRONMENT` from `settings.py`.** It was only referenced from that one broken call site; no need to keep dead config (CLAUDE.md YAGNI / kill-dead-code). The GH Actions secret can stay configured — unused env vars are harmless.
- **Pin `pinecone>=9,<10`** in `requirements.txt`. Next major could break again the same way; with a pin, the surprise happens at install time (loud, easy to bisect, recoverable) rather than at 02:30 in cron (silent until next morning). Lower-risk choice than leaving it unpinned.
- **Replace the existing mocked `test_initialize_pinecone`** with one that exercises the real `Pinecone` class. The old test patched `Pinecone` itself, so it cheerfully accepted any kwargs — that's why this regression shipped through CI silently. The new test instantiates the real client with a fake API key (no network call on init), so any future SDK that drops another kwarg fails loudly at test time. TDD'd: reproduced the exact CI error locally before fixing.

## Test plan

- [x] New regression test fails on unpatched code with the exact CI error
- [x] New regression test passes after fix
- [x] All 56 tests in `tests/align_data/embeddings/` pass
- [ ] Next scheduled cron run (or manual workflow dispatch) completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)